### PR TITLE
ci: enforce minimum code coverage threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,5 +40,5 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --configuration Release
 
-      - name: Test
+      - name: Test (with coverage gate)
         run: dotnet test --no-build --configuration Release

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+  <!-- Apply only to test projects -->
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
+    <CollectCoverage>true</CollectCoverage>
+    <CoverletOutputFormat>coverage</CoverletOutputFormat>
+
+    <!-- Coverage gate -->
+    <ThresholdType>line</ThresholdType>
+    <ThresholdStat>total</ThresholdStat>
+    <Threshold>70</Threshold>
+  </PropertyGroup>
+</Project>

--- a/tests/IntegrationTests/EventPlatform.IntegrationTests.csproj
+++ b/tests/IntegrationTests/EventPlatform.IntegrationTests.csproj
@@ -9,6 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="coverlet.msbuild" Version="8.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Testcontainers" Version="4.10.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.10.0" />

--- a/tests/UnitTests/EventPlatform.UnitTests.csproj
+++ b/tests/UnitTests/EventPlatform.UnitTests.csproj
@@ -9,6 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="coverlet.msbuild" Version="8.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />


### PR DESCRIPTION
Add Coverlet and a 70% line coverage gate (total). CI fails when coverage drops below the threshold.

## Summary
Explain what changed and why.

## Related Issue
Closes #12

## Checklist
- [ ] Linked to an issue (Closes/Fixes/Resolves/Refs #X)
- [ ] Follows architecture boundaries
- [ ] Tests updated/added if needed
- [ ] CI is green
