### PR TITLE
ci: enforce coverage gate and publish report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -19,7 +23,6 @@ jobs:
           POSTGRES_DB: event_platform
         ports:
           - 5432:5432
-
       redis:
         image: redis:7
         ports:
@@ -40,5 +43,71 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --configuration Release
 
-      - name: Test (with coverage gate)
+      # Runs tests + enforces thresholds from Directory.Build.props
+      - name: Test (coverage gate: line>=70, branch>=50)
         run: dotnet test --no-build --configuration Release
+
+      # Generate consolidated report (HTML + markdown summary + merged Cobertura)
+      - name: Install ReportGenerator
+        run: dotnet tool install -g dotnet-reportgenerator-globaltool
+
+      - name: Generate coverage report
+        shell: bash
+        run: |
+          reportgenerator \
+            -reports:"**/coverage.cobertura.xml" \
+            -targetdir:"coverage-report" \
+            -reporttypes:"HtmlInline;MarkdownSummaryGithub;Cobertura"
+          ls -la coverage-report
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage-report
+          if-no-files-found: error
+          retention-days: 14
+
+      # Comment summary on PR (only on pull_request)
+      - name: Comment coverage on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            // ReportGenerator creates this file for MarkdownSummaryGithub
+            const summaryPath = 'coverage-report/SummaryGithub.md';
+            if (!fs.existsSync(summaryPath)) {
+              core.setFailed(`Coverage summary not found at ${summaryPath}`);
+              return;
+            }
+
+            const summary = fs.readFileSync(summaryPath, 'utf8');
+            const marker = '<!-- coverage-summary -->';
+            const body = `${marker}\n## Coverage Report\n\n${summary}\n\n📦 Artifact: **coverage-report**`;
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+
+            // Find existing bot comment
+            const comments = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.data.find(c =>
+              c.user?.type === 'Bot' && c.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,11 +2,13 @@
   <!-- Apply only to test projects -->
   <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
     <CollectCoverage>true</CollectCoverage>
+
+    <!-- Generate Coverage per test project -->
     <CoverletOutputFormat>coverage</CoverletOutputFormat>
 
     <!-- Coverage gate -->
-    <ThresholdType>line</ThresholdType>
     <ThresholdStat>total</ThresholdStat>
-    <Threshold>70</Threshold>
+    <ThresholdType>line,branch</ThresholdType>
+    <Threshold>70,50</Threshold>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Enforce total coverage thresholds (line>=70%, branch>=50%), generate consolidated HTML report, upload artifact, and comment coverage summary on PRs.

## Summary
Explain what changed and why.

## Related Issue
Closes #12 

## Checklist
- [ ] Linked to an issue (Closes/Fixes/Resolves/Refs #X)
- [ ] Follows architecture boundaries
- [ ] Tests updated/added if needed
- [ ] CI is green
