### PR TITLE
feat(db): add event_platform schema and events table with idempotency…

### DIFF
--- a/EventPlatform.slnx
+++ b/EventPlatform.slnx
@@ -2,6 +2,7 @@
   <Folder Name="/src/">
     <Project Path="src/EventIngestion.Api/EventIngestion.Api.csproj" />
     <Project Path="src/EventPlatform.Application/EventPlatform.Application.csproj" />
+    <Project Path="src/EventPlatform.DbMigrator/EventPlatform.DbMigrator.csproj" />
     <Project Path="src/EventPlatform.Domain/EventPlatform.Domain.csproj" />
     <Project Path="src/EventPlatform.Infrastructure/EventPlatform.Infrastructure.csproj" />
     <Project Path="src/EventWorker/EventWorker.csproj" />

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -1,14 +1,16 @@
 services:
-  postgres:
-    image: postgres:16
+  event_platform_postgres:
+    image: postgres:latest
+    container_name: event_platform_postgres
     environment:
       POSTGRES_DB: event_platform
       POSTGRES_USER: event_platform
       POSTGRES_PASSWORD: event_platform
     ports:
-      - "5432:5432"
+      - "54320:5432"
 
-  redis:
-    image: redis:7
+  event_platform_redis:
+    image: redis:latest
+    container_name: event_platform_redis
     ports:
-      - "6379:6379"
+      - "63790:6379"

--- a/migrations/postgres/001_create_schema.sql
+++ b/migrations/postgres/001_create_schema.sql
@@ -1,0 +1,4 @@
+CREATE SCHEMA IF NOT EXISTS event_platform;
+
+-- Needed if you use gen_random_uuid() anywhere
+CREATE EXTENSION IF NOT EXISTS pgcrypto;

--- a/migrations/postgres/002_create_events_table.sql
+++ b/migrations/postgres/002_create_events_table.sql
@@ -1,0 +1,61 @@
+CREATE TABLE IF NOT EXISTS event_platform.events (
+  id                uuid PRIMARY KEY,
+
+  tenant_id          text        NOT NULL,
+  event_type         text        NOT NULL,
+
+  occurred_at        timestamptz NOT NULL,
+  received_at        timestamptz NOT NULL DEFAULT now(),
+
+  payload            jsonb       NOT NULL,
+
+  idempotency_key    text        NULL,
+  correlation_id     uuid        NOT NULL,
+
+  status             text        NOT NULL,
+  attempts           integer     NOT NULL DEFAULT 0,
+  next_attempt_at    timestamptz NULL,
+  last_error         text        NULL
+);
+
+-- Idempotency per tenant (only when key is present)
+CREATE UNIQUE INDEX IF NOT EXISTS ux_events_tenant_idempotency_key
+  ON event_platform.events (tenant_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+-- Worker polling
+CREATE INDEX IF NOT EXISTS ix_events_status_next_attempt_at
+  ON event_platform.events (status, next_attempt_at);
+
+-- Tenant timeline
+CREATE INDEX IF NOT EXISTS ix_events_tenant_received_at_desc
+  ON event_platform.events (tenant_id, received_at DESC);
+
+-- Type timeline
+CREATE INDEX IF NOT EXISTS ix_events_type_received_at_desc
+  ON event_platform.events (event_type, received_at DESC);
+
+-- Correlation tracing
+CREATE INDEX IF NOT EXISTS ix_events_correlation_id
+  ON event_platform.events (correlation_id);
+
+-- Guardrails
+ALTER TABLE event_platform.events
+  ADD CONSTRAINT chk_events_attempts_nonneg CHECK (attempts >= 0);
+
+ALTER TABLE event_platform.events
+  ADD CONSTRAINT chk_events_tenant_id_not_blank CHECK (length(btrim(tenant_id)) > 0);
+
+ALTER TABLE event_platform.events
+  ADD CONSTRAINT chk_events_event_type_not_blank CHECK (length(btrim(event_type)) > 0);
+
+ALTER TABLE event_platform.events
+  ADD CONSTRAINT chk_events_status_allowed
+  CHECK (status IN (
+    'RECEIVED',
+    'QUEUED',
+    'PROCESSING',
+    'SUCCEEDED',
+    'FAILED_RETRYABLE',
+    'FAILED_TERMINAL'
+  ));

--- a/src/EventPlatform.DbMigrator/EventPlatform.DbMigrator.csproj
+++ b/src/EventPlatform.DbMigrator/EventPlatform.DbMigrator.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <NuGetAuditMode>direct</NuGetAuditMode>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="dbup" Version="5.0.41" />
+    <PackageReference Include="dbup-postgresql" Version="7.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\..\migrations\postgres\*.sql">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/src/EventPlatform.DbMigrator/Program.cs
+++ b/src/EventPlatform.DbMigrator/Program.cs
@@ -1,0 +1,48 @@
+﻿using DbUp;
+using DbUp.Engine;
+
+var connectionString = Environment.GetEnvironmentVariable("EVENTPLATFORM_DB") ?? throw new InvalidOperationException("DB_CONNECTION_STRING environment variable is not set.");
+
+Console.WriteLine("Runing database migration...");
+Console.WriteLine($"DB: {Redact(connectionString)}");
+
+var scriptsPath = Path.Combine(AppContext.BaseDirectory);
+
+UpgradeEngine upgrader =
+    DeployChanges.To
+        .PostgresqlDatabase(connectionString)
+        .WithScriptsFromFileSystem(
+            scriptsPath,
+            f => f.EndsWith(".sql", StringComparison.OrdinalIgnoreCase))
+        .LogToConsole()
+        .Build();
+
+var result = upgrader.PerformUpgrade();
+
+if (!result.Successful)
+{
+    Console.Error.WriteLine(result.Error);
+    Environment.ExitCode = -1;
+    return;
+}
+
+Console.WriteLine("✅ Database migrations applied successfully.");
+
+static string Redact(string cs)
+{
+    // Covers: Password=...; Pwd=...
+    var parts = cs.Split(';', StringSplitOptions.RemoveEmptyEntries);
+    for (var i = 0; i < parts.Length; i++)
+    {
+        var kv = parts[i].Split('=', 2);
+        if (kv.Length != 2) continue;
+
+        var key = kv[0].Trim();
+        if (key.Equals("Password", StringComparison.OrdinalIgnoreCase) ||
+            key.Equals("Pwd", StringComparison.OrdinalIgnoreCase))
+        {
+            parts[i] = $"{key}=***";
+        }
+    }
+    return string.Join(';', parts);
+}


### PR DESCRIPTION
## Summary
Introduces the foundational persistence layer for the Event Platform.

## Changes
- Added `event_platform` schema
- Added `events` table as the system of record
- Implemented DB-level idempotency constraint
- Added indexes optimized for worker polling and tracing
- Added integrity constraints for status and attempts
- Introduced DbMigrator project (DbUp)
- Added PostgreSQL docker configuration

## Design Notes
Idempotency is enforced at the database level using a partial unique index.
PostgreSQL acts as the source of truth for event state transitions.

## Validation
- Migration executed successfully via DbUp
- Table and indexes verified
- Unique constraint validated for idempotency

## Related Issue
Closes #1 

## Checklist
- [x] Linked to an issue (Closes/Fixes/Resolves/Refs #X)
- [x] Follows architecture boundaries
- [x] Tests updated/added if needed
- [x] CI is green
