### PR TITLE
feat(infrastructure): add typed exception handling for event repository

### DIFF
--- a/src/EventPlatform.Infrastructure/Persistence/Exceptions/EventRepositoryException.cs
+++ b/src/EventPlatform.Infrastructure/Persistence/Exceptions/EventRepositoryException.cs
@@ -1,0 +1,63 @@
+namespace EventPlatform.Infrastructure.Persistence.Exceptions;
+
+/// <summary>
+/// Base exception for repository persistence failures.
+/// </summary>
+public abstract class EventRepositoryException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventRepositoryException"/> class.
+    /// </summary>
+    /// <param name="message">The exception message.</param>
+    /// <param name="innerException">The original exception.</param>
+    /// <param name="isTransient">Whether the error is transient.</param>
+    protected EventRepositoryException(string message, Exception innerException, bool isTransient)
+        : base(message, innerException)
+    {
+        IsTransient = isTransient;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the error is transient.
+    /// </summary>
+    public bool IsTransient { get; }
+}
+
+/// <summary>
+/// Exception raised when an idempotency conflict occurs.
+/// </summary>
+public sealed class EventRepositoryConflictException : EventRepositoryException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventRepositoryConflictException"/> class.
+    /// </summary>
+    /// <param name="message">The exception message.</param>
+    /// <param name="constraintName">The violated constraint name, if available.</param>
+    /// <param name="innerException">The original exception.</param>
+    public EventRepositoryConflictException(string message, string? constraintName, Exception innerException)
+        : base(message, innerException, isTransient: false)
+    {
+        ConstraintName = constraintName;
+    }
+
+    /// <summary>
+    /// Gets the violated constraint name when available.
+    /// </summary>
+    public string? ConstraintName { get; }
+}
+
+/// <summary>
+/// Exception raised for transient persistence errors.
+/// </summary>
+public sealed class EventRepositoryTransientException : EventRepositoryException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventRepositoryTransientException"/> class.
+    /// </summary>
+    /// <param name="message">The exception message.</param>
+    /// <param name="innerException">The original exception.</param>
+    public EventRepositoryTransientException(string message, Exception innerException)
+        : base(message, innerException, isTransient: true)
+    {
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce a dedicated repository exception hierarchy to classify persistence failures.
- Add `EventRepositoryConflictException` for idempotency/unique-constraint conflicts.
- Add `EventRepositoryTransientException` for transient database failures.
- Implement centralized exception mapping in repository operations.
- Map SQL state 23505 (unique violation) to conflict exceptions with constraint metadata.
- Map SQL state 57P03 and timeout failures to transient exceptions.
- Preserve unknown/unmapped exceptions by rethrowing them unchanged.
- Keep cancellation-token behavior intact while adding error classification.
- Extend unit tests to validate conflict and transient mappings.
- Add configurable fake ADO components in tests to simulate SQL-state and timeout failures.
- Improve reliability for upstream flows that need to distinguish duplicate, transient, and fatal paths.
- Refs #22; supports downstream behavior expected by #4, #8, and #10.

## Related Issue
Closes #22 
Refs #2 

## Checklist
- [x] Linked to an issue (Closes/Fixes/Resolves/Refs #X)
- [x] Follows architecture boundaries
- [x] Tests updated/added if needed
- [ ] CI is green
