### PR TITLE
feat(infrastructure): add pagination to GetRetryableEventsAsync

### DIFF
--- a/src/EventPlatform.Infrastructure/Persistence/Internal/EventQueries.cs
+++ b/src/EventPlatform.Infrastructure/Persistence/Internal/EventQueries.cs
@@ -49,10 +49,10 @@ internal static class EventQueries
         LIMIT 1";
 
     /// <summary>
-    /// SQL query to retrieve all events with FAILED_RETRYABLE status
+    /// SQL query to retrieve paged events with FAILED_RETRYABLE status
     /// and next_attempt_at <= current time.
     /// </summary>
-    public const string GetRetryableEvents = @"
+    public const string GetRetryableEventsPage = @"
         SELECT
             id, tenant_id, event_type, occurred_at, received_at,
             payload, idempotency_key, correlation_id, status, attempts,
@@ -60,5 +60,7 @@ internal static class EventQueries
         FROM events
         WHERE status = @Status
           AND next_attempt_at <= @Now
-        ORDER BY next_attempt_at ASC";
+        ORDER BY next_attempt_at ASC, id ASC
+        LIMIT @Take
+        OFFSET @Skip";
 }

--- a/src/EventPlatform.Infrastructure/Persistence/Repositories/IEventRepository.cs
+++ b/src/EventPlatform.Infrastructure/Persistence/Repositories/IEventRepository.cs
@@ -42,10 +42,16 @@ public interface IEventRepository
     Task<EventEnvelope?> GetByIdAsync(Guid eventId, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Retrieves all events with retryable status and a scheduled retry time <= the current time.
+    /// Retrieves retryable events with pagination metadata.
     /// </summary>
     /// <param name="now">The current time reference.</param>
+    /// <param name="pageSize">The maximum number of events to return. Defaults to 1000.</param>
+    /// <param name="skip">The number of events to skip. Defaults to 0.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A collection of retryable event envelopes.</returns>
-    Task<IEnumerable<EventEnvelope>> GetRetryableEventsAsync(DateTimeOffset now, CancellationToken cancellationToken = default);
+    /// <returns>A paginated retryable event result with metadata.</returns>
+    Task<RetryableEventsPage> GetRetryableEventsAsync(
+        DateTimeOffset now,
+        int pageSize = 1000,
+        int skip = 0,
+        CancellationToken cancellationToken = default);
 }

--- a/src/EventPlatform.Infrastructure/Persistence/Repositories/RetryableEventsPage.cs
+++ b/src/EventPlatform.Infrastructure/Persistence/Repositories/RetryableEventsPage.cs
@@ -1,0 +1,50 @@
+using EventPlatform.Domain.Events;
+
+namespace EventPlatform.Infrastructure.Persistence.Repositories;
+
+/// <summary>
+/// Represents a paginated result for retryable events.
+/// </summary>
+public sealed class RetryableEventsPage
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RetryableEventsPage"/> class.
+    /// </summary>
+    /// <param name="items">The events included in the current page.</param>
+    /// <param name="hasMore">Whether there are more events available after this page.</param>
+    /// <param name="skip">The number of events skipped.</param>
+    /// <param name="pageSize">The requested page size.</param>
+    public RetryableEventsPage(IReadOnlyList<EventEnvelope> items, bool hasMore, int skip, int pageSize)
+    {
+        Items = items ?? throw new ArgumentNullException(nameof(items));
+        Count = items.Count;
+        HasMore = hasMore;
+        Skip = skip;
+        PageSize = pageSize;
+    }
+
+    /// <summary>
+    /// Gets the events included in the current page.
+    /// </summary>
+    public IReadOnlyList<EventEnvelope> Items { get; }
+
+    /// <summary>
+    /// Gets the number of events returned in the current page.
+    /// </summary>
+    public int Count { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether more events are available.
+    /// </summary>
+    public bool HasMore { get; }
+
+    /// <summary>
+    /// Gets the number of events skipped.
+    /// </summary>
+    public int Skip { get; }
+
+    /// <summary>
+    /// Gets the requested page size.
+    /// </summary>
+    public int PageSize { get; }
+}

--- a/tests/UnitTests/Infrastructure/Persistence/Repositories/EventRepositoryTests.cs
+++ b/tests/UnitTests/Infrastructure/Persistence/Repositories/EventRepositoryTests.cs
@@ -222,10 +222,15 @@ public class EventRepositoryTests
         var now = DateTimeOffset.UtcNow;
 
         // Act
-        var result = await _sut.GetRetryableEventsAsync(now);
+        var result = await _sut.GetRetryableEventsAsync(now, pageSize: 1000, skip: 0);
 
         // Assert
         Assert.Equal(1, fakeConnection.OpenCount);
+        Assert.NotNull(result);
+        Assert.Equal(0, result.Count);
+        Assert.False(result.HasMore);
+        Assert.Equal(1000, result.PageSize);
+        Assert.Equal(0, result.Skip);
     }
 
     [Fact]
@@ -236,7 +241,23 @@ public class EventRepositoryTests
 
         // Act & Assert
         await Assert.ThrowsAsync<OperationCanceledException>(
-            () => _sut.GetRetryableEventsAsync(DateTimeOffset.UtcNow, cancellationToken));
+            () => _sut.GetRetryableEventsAsync(DateTimeOffset.UtcNow, cancellationToken: cancellationToken));
+    }
+
+    [Fact]
+    public async Task GetRetryableEventsAsync_ThrowsArgumentOutOfRangeException_WhenPageSizeIsInvalid()
+    {
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            () => _sut.GetRetryableEventsAsync(DateTimeOffset.UtcNow, pageSize: 0, skip: 0));
+    }
+
+    [Fact]
+    public async Task GetRetryableEventsAsync_ThrowsArgumentOutOfRangeException_WhenSkipIsNegative()
+    {
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            () => _sut.GetRetryableEventsAsync(DateTimeOffset.UtcNow, pageSize: 10, skip: -1));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Add paginated retryable-events contract with metadata via `RetryableEventsPage`.
- Extend `IEventRepository.GetRetryableEventsAsync` to accept `pageSize` and `skip` parameters with sensible defaults.
- Implement FIFO-stable pagination query using ORDER BY next_attempt_at, id with LIMIT/OFFSET.
- Add repository-level validation for pagination arguments:
  - `pageSize` must be greater than zero
  - `skip` must be zero or greater
- Implement hasMore detection using fetch-one-extra strategy (pageSize + 1) and trim the extra item.
- Return pagination metadata (count, `hasMore`, `skip`, `pageSize`) alongside page items.
- Keep existing cancellation and exception-mapping behavior intact in repository flow.
- Update unit tests to the new method signature and return type assertions.
- Add new tests for invalid `pageSize` and negative `skip` argument handling.
- Verify full unit-test pass after changes.

supports retry scheduler batching expected by #10.

## Related Issue
Closes #23 
Refs #2 

## Checklist
- [x] Linked to an issue (Closes  #23 / Refs #2)
- [x] Follows architecture boundaries
- [x] Tests updated/added if needed
- [] CI is green
