### PR TITLE
feat(infrastructure): add operational query methods for event monitoring

### DIFF
--- a/migrations/postgres/003_add_operational_query_indexes.sql
+++ b/migrations/postgres/003_add_operational_query_indexes.sql
@@ -1,0 +1,3 @@
+-- Improves count-by-status with optional tenant filter used by operational monitoring queries.
+CREATE INDEX IF NOT EXISTS ix_events_status_tenant_id
+  ON event_platform.events (status, tenant_id);

--- a/src/EventPlatform.Infrastructure/Persistence/Repositories/IEventRepository.cs
+++ b/src/EventPlatform.Infrastructure/Persistence/Repositories/IEventRepository.cs
@@ -68,4 +68,50 @@ public interface IEventRepository
         int pageSize = 1000,
         int skip = 0,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Counts events by status, optionally filtered by tenant.
+    /// </summary>
+    /// <param name="status">The event status to count.</param>
+    /// <param name="tenantId">Optional tenant filter.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The number of events matching the criteria.</returns>
+    Task<long> GetCountAsync(
+        EventStatus status,
+        string? tenantId = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves all events with the specified correlation ID.
+    /// </summary>
+    /// <param name="correlationId">The correlation ID.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The events associated with the correlation ID.</returns>
+    Task<IReadOnlyList<EventEnvelope>> GetByCorrelationIdAsync(
+        Guid correlationId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves events for a tenant with pagination.
+    /// </summary>
+    /// <param name="tenantId">The tenant ID.</param>
+    /// <param name="pageSize">The maximum number of events to return. Defaults to 100.</param>
+    /// <param name="skip">The number of events to skip. Defaults to 0.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The events for the tenant.</returns>
+    Task<IReadOnlyList<EventEnvelope>> GetByTenantIdAsync(
+        string tenantId,
+        int pageSize = 100,
+        int skip = 0,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the single oldest retryable event eligible for processing.
+    /// </summary>
+    /// <param name="now">The current time reference.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The oldest retryable event, or null if none exist.</returns>
+    Task<EventEnvelope?> GetOldestRetryableAsync(
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default);
 }

--- a/tests/UnitTests/Infrastructure/Persistence/Repositories/EventRepositoryTests.cs
+++ b/tests/UnitTests/Infrastructure/Persistence/Repositories/EventRepositoryTests.cs
@@ -260,6 +260,164 @@ public class EventRepositoryTests
             () => _sut.GetRetryableEventsAsync(DateTimeOffset.UtcNow, pageSize: 10, skip: -1));
     }
 
+    [Fact]
+    public async Task GetCountAsync_OpensConnection_WhenCountingByStatus()
+    {
+        // Arrange
+        var fakeConnection = new FakeDbConnection();
+
+        _mockConnectionFactory
+            .Setup(cf => cf.CreateConnection())
+            .Returns(fakeConnection);
+
+        // Act
+        var result = await _sut.GetCountAsync(EventStatus.SUCCEEDED);
+
+        // Assert
+        Assert.Equal(1, fakeConnection.OpenCount);
+        Assert.Equal(0L, result);
+    }
+
+    [Fact]
+    public async Task GetCountAsync_ThrowsOperationCanceledException_WhenCancellationRequested()
+    {
+        // Arrange
+        var cancellationToken = CreateCanceledToken();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => _sut.GetCountAsync(EventStatus.SUCCEEDED, cancellationToken: cancellationToken));
+    }
+
+    [Fact]
+    public async Task GetCountAsync_ThrowsArgumentException_WhenTenantIdIsBlank()
+    {
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _sut.GetCountAsync(EventStatus.SUCCEEDED, tenantId: "  "));
+    }
+
+    [Fact]
+    public async Task GetByCorrelationIdAsync_OpensConnection_WhenRetrievingEvents()
+    {
+        // Arrange
+        var fakeConnection = new FakeDbConnection();
+
+        _mockConnectionFactory
+            .Setup(cf => cf.CreateConnection())
+            .Returns(fakeConnection);
+
+        // Act
+        var result = await _sut.GetByCorrelationIdAsync(Guid.NewGuid());
+
+        // Assert
+        Assert.Equal(1, fakeConnection.OpenCount);
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetByCorrelationIdAsync_ThrowsOperationCanceledException_WhenCancellationRequested()
+    {
+        // Arrange
+        var cancellationToken = CreateCanceledToken();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => _sut.GetByCorrelationIdAsync(Guid.NewGuid(), cancellationToken));
+    }
+
+    [Fact]
+    public async Task GetByCorrelationIdAsync_ThrowsArgumentException_WhenCorrelationIdIsEmpty()
+    {
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _sut.GetByCorrelationIdAsync(Guid.Empty));
+    }
+
+    [Fact]
+    public async Task GetByTenantIdAsync_OpensConnection_WhenRetrievingTenantEvents()
+    {
+        // Arrange
+        var fakeConnection = new FakeDbConnection();
+
+        _mockConnectionFactory
+            .Setup(cf => cf.CreateConnection())
+            .Returns(fakeConnection);
+
+        // Act
+        var result = await _sut.GetByTenantIdAsync("test-tenant", pageSize: 25, skip: 0);
+
+        // Assert
+        Assert.Equal(1, fakeConnection.OpenCount);
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetByTenantIdAsync_ThrowsOperationCanceledException_WhenCancellationRequested()
+    {
+        // Arrange
+        var cancellationToken = CreateCanceledToken();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => _sut.GetByTenantIdAsync("test-tenant", cancellationToken: cancellationToken));
+    }
+
+    [Fact]
+    public async Task GetByTenantIdAsync_ThrowsArgumentException_WhenTenantIdIsBlank()
+    {
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _sut.GetByTenantIdAsync(" "));
+    }
+
+    [Fact]
+    public async Task GetByTenantIdAsync_ThrowsArgumentOutOfRangeException_WhenPageSizeIsInvalid()
+    {
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            () => _sut.GetByTenantIdAsync("test-tenant", pageSize: 0, skip: 0));
+    }
+
+    [Fact]
+    public async Task GetByTenantIdAsync_ThrowsArgumentOutOfRangeException_WhenSkipIsNegative()
+    {
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            () => _sut.GetByTenantIdAsync("test-tenant", pageSize: 10, skip: -1));
+    }
+
+    [Fact]
+    public async Task GetOldestRetryableAsync_OpensConnection_WhenRetrievingOldestRetryableEvent()
+    {
+        // Arrange
+        var fakeConnection = new FakeDbConnection();
+
+        _mockConnectionFactory
+            .Setup(cf => cf.CreateConnection())
+            .Returns(fakeConnection);
+
+        // Act
+        var result = await _sut.GetOldestRetryableAsync(DateTimeOffset.UtcNow);
+
+        // Assert
+        Assert.Equal(1, fakeConnection.OpenCount);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetOldestRetryableAsync_ThrowsOperationCanceledException_WhenCancellationRequested()
+    {
+        // Arrange
+        var cancellationToken = CreateCanceledToken();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => _sut.GetOldestRetryableAsync(DateTimeOffset.UtcNow, cancellationToken));
+    }
+
     /// <summary>
     /// Helper method to create a valid EventEnvelope for testing.
     /// </summary>


### PR DESCRIPTION
## Summary
This PR implements issue #26 by adding operational query methods to the infrastructure repository layer for monitoring, tracing, and tenant-level diagnostics.

## What was added

### Repository contract and implementation
- Added `GetCountAsync(EventStatus status, string? tenantId = null, CancellationToken cancellationToken = default)`
- Added `GetByCorrelationIdAsync(Guid correlationId, CancellationToken cancellationToken = default)`
- Added `GetByTenantIdAsync(string tenantId, int pageSize = 100, int skip = 0, CancellationToken cancellationToken = default)`
- Added `GetOldestRetryableAsync(DateTimeOffset now, CancellationToken cancellationToken = default)`

### SQL queries
- Added count-by-status query with optional tenant filter.
- Added correlation-id lookup query (chronological order).
- Added tenant paginated query (latest first).
- Added oldest-retryable single-item query (`FAILED_RETRYABLE`, `next_attempt_at <= now`, `LIMIT 1`).

### Migration and indexing
- Added migration `003_add_operational_query_indexes.sql` with:
  - `ix_events_status_tenant_id` on `(status, tenant_id)`

## Why
These methods support:
- Health and operational monitoring (status counts)
- Correlation-based tracing and debugging
- Tenant-level event diagnostics
- More efficient scheduler retrieval of retryable work items

## Validation
- Added unit tests for all new methods in `EventRepositoryTests`:
  - happy-path connection behavior
  - cancellation handling
  - input validation guards
- Repository unit tests pass.

## Notes
- This PR focuses on persistence/infrastructure capabilities.
- API/worker consumption points can integrate these methods in follow-up issues.

## Related Issue
Closes #26 
Refs #2 

## Checklist
- [x] Linked to an issue (Closes #26 / Refs #2)
- [x] Follows architecture boundaries
- [x] Tests updated/added if needed
- [ ] CI is green
