### PR TITLE
feat(api): persist source in events table and rehydrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to Semantic Versioning.
 - Idempotent ingestion endpoint
 - Async worker processing
 - Retry mechanism with exponential backoff
+- Persist and rehydrate `source` field for improved traceability (#36)
 
 ---
 

--- a/docs/02-event-contract.md
+++ b/docs/02-event-contract.md
@@ -17,6 +17,7 @@
 
 ## Required fields
 
+- `source`
 - `event_type`
 - `tenant_id`
 - `idempotency_key`

--- a/docs/04-data-model.md
+++ b/docs/04-data-model.md
@@ -7,6 +7,7 @@ Table: events
 - event_type (text)
 - occurred_at (timestamptz)
 - received_at (timestamptz)
+- source (text)
 - payload (jsonb)
 - idempotency_key (text)
 - correlation_id (uuid)

--- a/migrations/postgres/005_add_source_to_events.sql
+++ b/migrations/postgres/005_add_source_to_events.sql
@@ -1,0 +1,29 @@
+-- Add source column to events table for better traceability
+-- Persists the original source value instead of using a synthetic marker
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'event_platform'
+      AND table_name = 'events'
+      AND column_name = 'source'
+  ) THEN
+    ALTER TABLE event_platform.events
+      ADD COLUMN source text NOT NULL DEFAULT 'UNKNOWN';
+  END IF;
+END $$;
+
+-- Add constraint to ensure source is not blank
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'chk_events_source_not_blank'
+  ) THEN
+    ALTER TABLE event_platform.events
+      ADD CONSTRAINT chk_events_source_not_blank CHECK (length(btrim(source)) > 0);
+  END IF;
+END $$;

--- a/src/EventPlatform.Infrastructure/Persistence/Repositories/EventRepository.cs
+++ b/src/EventPlatform.Infrastructure/Persistence/Repositories/EventRepository.cs
@@ -55,7 +55,8 @@ public sealed class EventRepository : IEventRepository
             Status = envelope.Status.ToString(),
             envelope.Attempts,
             envelope.NextAttemptAt,
-            envelope.LastError
+            envelope.LastError,
+            envelope.Source
         };
 
         var command = new CommandDefinition(
@@ -111,7 +112,8 @@ public sealed class EventRepository : IEventRepository
                 Status = envelope.Status.ToString(),
                 envelope.Attempts,
                 envelope.NextAttemptAt,
-                envelope.LastError
+                envelope.LastError,
+                envelope.Source
             };
 
             var eventCommand = new CommandDefinition(
@@ -231,6 +233,7 @@ public sealed class EventRepository : IEventRepository
         var attemptsArray = new int[chunk.Length];
         var nextAttemptAts = new DateTime[chunk.Length]; // Use DateTime.MinValue as sentinel for null
         var lastErrors = new string[chunk.Length]; // Use empty string as sentinel for null
+        var sources = new string[chunk.Length];
 
         for (int i = 0; i < chunk.Length; i++)
         {
@@ -247,6 +250,7 @@ public sealed class EventRepository : IEventRepository
             attemptsArray[i] = envelope.Attempts;
             nextAttemptAts[i] = envelope.NextAttemptAt?.UtcDateTime ?? DateTime.MinValue; // Sentinel for null
             lastErrors[i] = envelope.LastError ?? string.Empty; // Sentinel for null
+            sources[i] = envelope.Source;
         }
 
         var parameters = new
@@ -262,7 +266,8 @@ public sealed class EventRepository : IEventRepository
             Statuses = statuses,
             AttemptsArray = attemptsArray,
             NextAttemptAts = nextAttemptAts,
-            LastErrors = lastErrors
+            LastErrors = lastErrors,
+            Sources = sources
         };
 
         var command = new CommandDefinition(
@@ -790,6 +795,7 @@ public sealed class EventRepository : IEventRepository
         public int Attempts { get; set; }
         public DateTimeOffset? NextAttemptAt { get; set; }
         public string? LastError { get; set; }
+        public string Source { get; set; } = null!;
 
         /// <summary>
         /// Converts this DTO to an EventEnvelope domain entity.
@@ -805,7 +811,7 @@ public sealed class EventRepository : IEventRepository
                 eventType: EventType,
                 occurredAt: OccurredAt,
                 receivedAt: ReceivedAt,
-                source: "PERSISTED", // Note: 'source' is not persisted; we use a marker value
+                source: Source,
                 tenantId: TenantId,
                 idempotencyKey: IdempotencyKey,
                 correlationId: CorrelationId,


### PR DESCRIPTION
## Summary

This PR implements persistence and rehydration of the `source` field in the event platform, addressing traceability concerns raised in issue #36.

**What changed:**
- Added `source` column to the `events` table with a NOT NULL constraint and validation
- Updated all persistence queries (8 total) to include `source` in SELECT and INSERT operations
- Modified `EventRepository` to pass the original `source` value during all insert operations (single, transactional, and batch)
- Updated `EventEnvelopeDto` mapping to rehydrate the original `source` value instead of the synthetic "PERSISTED" marker
- Enhanced documentation to reflect `source` as a required field in the event contract and data model

**Why:**
The `source` field is required by the domain model but was not persisted in PostgreSQL. Events were rehydrated with a synthetic "PERSISTED" value, losing the original source information and reducing traceability. This change ensures full data fidelity for audit and debugging purposes.

## Related Issue
Closes #36 
Refs #4 

## Technical Details

### Database Changes
- Migration `005_add_source_to_events.sql` adds the `source` column with a NOT NULL constraint
- Constraint added: `chk_events_source_not_blank` to ensure non-empty values

### Query Updates
Updated 8 SQL queries in `EventQueries.cs`:
1. `InsertEvent` - Added `source` parameter
2. `GetById` - Added `source` to SELECT clause
3. `GetByTenantAndIdempotencyKey` - Added `source` to SELECT clause
4. `GetRetryableEventsPage` - Added `source` to SELECT clause
5. `GetByCorrelationId` - Added `source` to SELECT clause
6. `GetByTenantIdPage` - Added `source` to SELECT clause
7. `GetOldestRetryable` - Added `source` to SELECT clause
8. `BatchInsertWithResults` - Added `@Sources::text[]` to UNNEST and `source` to normalized_data and INSERT

### Repository Changes
- `InsertAsync()` - Passes `envelope.Source` parameter
- `InsertWithOutboxAsync()` - Passes `envelope.Source` in transactional insert
- `BatchInsertChunkAsync()` - Builds `sources` array from envelopes
- `EventEnvelopeDto.ToEventEnvelope()` - Uses actual `Source` property instead of hardcoded "PERSISTED"

### Documentation Updates
- `docs/02-event-contract.md` - Added `source` to required fields list
- `docs/04-data-model.md` - Added `source (text)` to events table schema
- `CHANGELOG.md` - Added entry for feature

## Acceptance Criteria

- [x] Inserted events persist and return original `source` value
- [x] No breaking changes to existing ingestion flow
- [x] Idempotency mechanism continues functioning correctly
- [x] All 65 tests pass (Unit + Integration)
- [x] No compiler errors
- [x] Documentation updated

## Checklist
- [x] Linked to an issue (Closes #36 / Refs #4)
- [x] Follows architecture boundaries
- [x] Tests updated/added if needed
- [x] CI is green
