### PR TITLE
test(api): add E2E ingestion tests with Postgres+Redis containers

### DIFF
--- a/src/EventPlatform.Infrastructure/Persistence/Internal/EventQueries.cs
+++ b/src/EventPlatform.Infrastructure/Persistence/Internal/EventQueries.cs
@@ -16,7 +16,7 @@ internal static class EventQueries
         )
         VALUES (
             @Id, @TenantId, @EventType, @OccurredAt, @ReceivedAt,
-            @Payload, @IdempotencyKey, @CorrelationId, @Status, @Attempts,
+            @Payload::jsonb, @IdempotencyKey, @CorrelationId, @Status, @Attempts,
             @NextAttemptAt, @LastError, @Source
         )";
 
@@ -41,18 +41,38 @@ internal static class EventQueries
     /// </summary>
     public const string GetById = @"
         SELECT
-            id, tenant_id, event_type, occurred_at, received_at,
-            payload, idempotency_key, correlation_id, status, attempts,
-            next_attempt_at, last_error, source
+            id AS Id,
+            tenant_id AS TenantId,
+            event_type AS EventType,
+            occurred_at AS OccurredAt,
+            received_at AS ReceivedAt,
+            payload AS Payload,
+            idempotency_key AS IdempotencyKey,
+            correlation_id AS CorrelationId,
+            status AS Status,
+            attempts AS Attempts,
+            next_attempt_at AS NextAttemptAt,
+            last_error AS LastError,
+            source AS Source
         FROM events
         WHERE id = @EventId
         LIMIT 1";
 
     public const string GetByTenantAndIdempotencyKey = @"
         SELECT
-            id, tenant_id, event_type, occurred_at, received_at,
-            payload, idempotency_key, correlation_id, status, attempts,
-            next_attempt_at, last_error, source
+                        id AS Id,
+                        tenant_id AS TenantId,
+                        event_type AS EventType,
+                        occurred_at AS OccurredAt,
+                        received_at AS ReceivedAt,
+                        payload AS Payload,
+                        idempotency_key AS IdempotencyKey,
+                        correlation_id AS CorrelationId,
+                        status AS Status,
+                        attempts AS Attempts,
+                        next_attempt_at AS NextAttemptAt,
+                        last_error AS LastError,
+                        source AS Source
         FROM events
         WHERE tenant_id = @TenantId
           AND idempotency_key = @IdempotencyKey
@@ -65,9 +85,19 @@ internal static class EventQueries
     /// </summary>
     public const string GetRetryableEventsPage = @"
         SELECT
-            id, tenant_id, event_type, occurred_at, received_at,
-            payload, idempotency_key, correlation_id, status, attempts,
-            next_attempt_at, last_error, source
+                        id AS Id,
+                        tenant_id AS TenantId,
+                        event_type AS EventType,
+                        occurred_at AS OccurredAt,
+                        received_at AS ReceivedAt,
+                        payload AS Payload,
+                        idempotency_key AS IdempotencyKey,
+                        correlation_id AS CorrelationId,
+                        status AS Status,
+                        attempts AS Attempts,
+                        next_attempt_at AS NextAttemptAt,
+                        last_error AS LastError,
+                        source AS Source
         FROM events
         WHERE status = @Status
           AND next_attempt_at <= @Now
@@ -89,9 +119,19 @@ internal static class EventQueries
     /// </summary>
     public const string GetByCorrelationId = @"
         SELECT
-            id, tenant_id, event_type, occurred_at, received_at,
-            payload, idempotency_key, correlation_id, status, attempts,
-            next_attempt_at, last_error, source
+            id AS Id,
+            tenant_id AS TenantId,
+            event_type AS EventType,
+            occurred_at AS OccurredAt,
+            received_at AS ReceivedAt,
+            payload AS Payload,
+            idempotency_key AS IdempotencyKey,
+            correlation_id AS CorrelationId,
+            status AS Status,
+            attempts AS Attempts,
+            next_attempt_at AS NextAttemptAt,
+            last_error AS LastError,
+            source AS Source
         FROM events
         WHERE correlation_id = @CorrelationId
         ORDER BY received_at ASC, id ASC";
@@ -101,9 +141,19 @@ internal static class EventQueries
     /// </summary>
     public const string GetByTenantIdPage = @"
         SELECT
-            id, tenant_id, event_type, occurred_at, received_at,
-            payload, idempotency_key, correlation_id, status, attempts,
-            next_attempt_at, last_error, source
+            id AS Id,
+            tenant_id AS TenantId,
+            event_type AS EventType,
+            occurred_at AS OccurredAt,
+            received_at AS ReceivedAt,
+            payload AS Payload,
+            idempotency_key AS IdempotencyKey,
+            correlation_id AS CorrelationId,
+            status AS Status,
+            attempts AS Attempts,
+            next_attempt_at AS NextAttemptAt,
+            last_error AS LastError,
+            source AS Source
         FROM events
         WHERE tenant_id = @TenantId
         ORDER BY received_at DESC, id DESC
@@ -115,9 +165,19 @@ internal static class EventQueries
     /// </summary>
     public const string GetOldestRetryable = @"
         SELECT
-            id, tenant_id, event_type, occurred_at, received_at,
-            payload, idempotency_key, correlation_id, status, attempts,
-            next_attempt_at, last_error, source
+                        id AS Id,
+                        tenant_id AS TenantId,
+                        event_type AS EventType,
+                        occurred_at AS OccurredAt,
+                        received_at AS ReceivedAt,
+                        payload AS Payload,
+                        idempotency_key AS IdempotencyKey,
+                        correlation_id AS CorrelationId,
+                        status AS Status,
+                        attempts AS Attempts,
+                        next_attempt_at AS NextAttemptAt,
+                        last_error AS LastError,
+                        source AS Source
         FROM events
         WHERE status = @Status
           AND next_attempt_at <= @Now

--- a/src/EventPlatform.Infrastructure/Persistence/Internal/OutboxQueries.cs
+++ b/src/EventPlatform.Infrastructure/Persistence/Internal/OutboxQueries.cs
@@ -14,7 +14,7 @@ internal static class OutboxQueries
             publish_attempts, last_error
         )
         VALUES (
-            @Id, @EventId, @StreamName, @Payload, @CreatedAt, @PublishedAt,
+            @Id, @EventId, @StreamName, @Payload::jsonb, @CreatedAt, @PublishedAt,
             @PublishAttempts, @LastError
         )";
 
@@ -23,8 +23,14 @@ internal static class OutboxQueries
     /// </summary>
     public const string GetUnpublished = @"
         SELECT
-            id, event_id, stream_name, payload, created_at, published_at,
-            publish_attempts, last_error
+            id AS Id,
+            event_id AS EventId,
+            stream_name AS StreamName,
+            payload AS Payload,
+            created_at AS CreatedAt,
+            published_at AS PublishedAt,
+            publish_attempts AS PublishAttempts,
+            last_error AS LastError
         FROM event_platform.outbox_events
         WHERE published_at IS NULL
         ORDER BY created_at ASC

--- a/tests/IntegrationTests/Fixtures/CustomWebApplicationFactory.cs
+++ b/tests/IntegrationTests/Fixtures/CustomWebApplicationFactory.cs
@@ -1,43 +1,205 @@
-using EventPlatform.Application.Abstractions;
-using EventPlatform.IntegrationTests.Fakes;
+using DotNet.Testcontainers.Containers;
+using EventPlatform.Infrastructure;
+using Microsoft.AspNetCore.Hosting;
 using EventPlatform.Infrastructure.Messaging;
-using EventPlatform.Infrastructure.Persistence.Repositories;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Npgsql;
+using StackExchange.Redis;
+using Testcontainers.PostgreSql;
+using Testcontainers.Redis;
+using Xunit;
 
 namespace EventPlatform.IntegrationTests.Fixtures;
 
-public sealed class CustomWebApplicationFactory : WebApplicationFactory<Program>
+public sealed class CustomWebApplicationFactory : WebApplicationFactory<Program>, IAsyncLifetime
 {
-    public InMemoryEventRepository Repository { get; } = new();
-    public InMemoryEventPublisher Publisher { get; } = new();
-    public InMemoryOutboxRepository OutboxRepository { get; } = new();
+    private const string StreamName = "events:ingress";
+    private readonly PostgreSqlContainer _postgresContainer = new PostgreSqlBuilder("postgres:16-alpine")
+        .WithDatabase("event_platform")
+        .WithUsername("event_platform")
+        .WithPassword("event_platform")
+        .Build();
+    private readonly RedisContainer _redisContainer = new RedisBuilder("redis:7-alpine")
+        .Build();
 
-    public void ResetState()
+    private IConnectionMultiplexer? _redisMultiplexer;
+    private string? _previousDbEnvironmentValue;
+    private string? _previousRedisEnvironmentValue;
+
+    public string PostgresConnectionString { get; private set; } = string.Empty;
+    public string RedisConnectionString { get; private set; } = string.Empty;
+
+    public async Task ResetStateAsync()
     {
-        Repository.Clear();
-        Publisher.Clear();
-        OutboxRepository.Clear();
+        await using var connection = new NpgsqlConnection(PostgresConnectionString);
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = @"
+TRUNCATE TABLE event_platform.outbox_events, event_platform.events RESTART IDENTITY CASCADE;";
+        await command.ExecuteNonQueryAsync();
+
+        var redis = _redisMultiplexer?.GetDatabase()
+            ?? throw new InvalidOperationException("Redis multiplexer is not initialized.");
+
+        await redis.ExecuteAsync("FLUSHDB");
     }
 
-    protected override void ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder)
+    public async Task<int> CountEventsByTenantAndIdempotencyKeyAsync(string tenantId, string idempotencyKey)
     {
+        await using var connection = new NpgsqlConnection(PostgresConnectionString);
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = @"
+SELECT COUNT(*)
+FROM event_platform.events
+WHERE tenant_id = @tenant_id AND idempotency_key = @idempotency_key;";
+        command.Parameters.AddWithValue("tenant_id", tenantId);
+        command.Parameters.AddWithValue("idempotency_key", idempotencyKey);
+
+        var result = await command.ExecuteScalarAsync();
+        return Convert.ToInt32(result);
+    }
+
+    public async Task<long> GetStreamLengthAsync()
+    {
+        var redis = _redisMultiplexer?.GetDatabase()
+            ?? throw new InvalidOperationException("Redis multiplexer is not initialized.");
+
+        return await redis.StreamLengthAsync(StreamName);
+    }
+
+    public async Task WaitForStreamLengthAsync(long expectedLength, TimeSpan timeout)
+    {
+        var start = DateTimeOffset.UtcNow;
+
+        while (DateTimeOffset.UtcNow - start < timeout)
+        {
+            var currentLength = await GetStreamLengthAsync();
+            if (currentLength == expectedLength)
+            {
+                return;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+        }
+
+        var finalLength = await GetStreamLengthAsync();
+        throw new TimeoutException($"Timed out waiting for stream '{StreamName}' length {expectedLength}. Current length: {finalLength}.");
+    }
+
+    async Task IAsyncLifetime.InitializeAsync()
+    {
+        await Task.WhenAll(_postgresContainer.StartAsync(), _redisContainer.StartAsync());
+
+        PostgresConnectionString = _postgresContainer.GetConnectionString();
+        RedisConnectionString = _redisContainer.GetConnectionString();
+
+        _previousDbEnvironmentValue = Environment.GetEnvironmentVariable("EVENTPLATFORM_DB");
+        _previousRedisEnvironmentValue = Environment.GetEnvironmentVariable("EVENTPLATFORM_REDIS");
+        Environment.SetEnvironmentVariable("EVENTPLATFORM_DB", PostgresConnectionString);
+        Environment.SetEnvironmentVariable("EVENTPLATFORM_REDIS", RedisConnectionString);
+
+        _redisMultiplexer = await ConnectionMultiplexer.ConnectAsync(RedisConnectionString);
+
+        await ApplyMigrationsAsync();
+    }
+
+    async Task IAsyncLifetime.DisposeAsync()
+    {
+        base.Dispose();
+
+        if (_redisMultiplexer is not null)
+        {
+            await _redisMultiplexer.CloseAsync();
+            await _redisMultiplexer.DisposeAsync();
+        }
+
+        Environment.SetEnvironmentVariable("EVENTPLATFORM_DB", _previousDbEnvironmentValue);
+        Environment.SetEnvironmentVariable("EVENTPLATFORM_REDIS", _previousRedisEnvironmentValue);
+
+        await _redisContainer.DisposeAsync();
+        await _postgresContainer.DisposeAsync();
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Production");
+
+        builder.ConfigureAppConfiguration((_, configBuilder) =>
+        {
+            configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:EventPlatformDb"] = PostgresConnectionString,
+                ["ConnectionStrings:EventPlatformRedis"] = RedisConnectionString,
+                ["Ingestion:RedisStreamName"] = StreamName
+            });
+        });
+
         builder.ConfigureServices(services =>
         {
-            services.RemoveAll<IEventRepository>();
-            services.RemoveAll<IEventPublisher>();
-            services.RemoveAll<IOutboxRepository>();
-            services.RemoveAll<OutboxPublisherService>();
+            var outboxHostedServices = services
+                .Where(descriptor =>
+                    descriptor.ServiceType == typeof(IHostedService)
+                    && descriptor.ImplementationType == typeof(OutboxPublisherService))
+                .ToList();
 
-            services.AddSingleton<IEventRepository>(Repository);
-            services.AddSingleton<IEventPublisher>(Publisher);
-            services.AddSingleton<IOutboxRepository>(OutboxRepository);
+            foreach (var descriptor in outboxHostedServices)
+            {
+                services.Remove(descriptor);
+            }
 
-            // Set up the cross-reference so InMemoryEventRepository can insert outbox events
-            Repository.OutboxRepository = OutboxRepository;
-
-            // Don't run the OutboxPublisherService in tests - we test it separately
+            services.RemoveAll<IConfigureOptions<OutboxPublisherOptions>>();
+            services.AddOutboxPublisher(options =>
+            {
+                options.PollIntervalMilliseconds = 100;
+                options.MaxBatchSize = 100;
+            });
         });
+    }
+
+    private async Task ApplyMigrationsAsync()
+    {
+        var repositoryRoot = ResolveRepositoryRoot();
+        var migrationsDirectory = Path.Combine(repositoryRoot, "migrations", "postgres");
+        var migrationFiles = Directory
+            .GetFiles(migrationsDirectory, "*.sql")
+            .OrderBy(Path.GetFileName, StringComparer.Ordinal)
+            .ToArray();
+
+        await using var connection = new NpgsqlConnection(PostgresConnectionString);
+        await connection.OpenAsync();
+
+        foreach (var file in migrationFiles)
+        {
+            var sql = await File.ReadAllTextAsync(file);
+            await using var command = connection.CreateCommand();
+            command.CommandText = sql;
+            await command.ExecuteNonQueryAsync();
+        }
+    }
+
+    private static string ResolveRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (current is not null)
+        {
+            var solutionPath = Path.Combine(current.FullName, "EventPlatform.slnx");
+            if (File.Exists(solutionPath))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not resolve repository root from test execution directory.");
     }
 }


### PR DESCRIPTION
## Summary
This PR implements issue #37 by replacing in-memory ingestion integration tests with true end-to-end tests using Testcontainers (Postgres + Redis).

### What changed
- Reworked the integration test fixture to spin up isolated Postgres and Redis containers per test run.
- Added automatic SQL migration execution at fixture startup so schema is always consistent in local and CI runs.
- Added deterministic test state reset between tests (`TRUNCATE` in Postgres + `FLUSHDB` in Redis).
- Updated API E2E tests to validate real persistence and publish behavior:
  - **new ingestion flow**: returns `202 Accepted`, persists one row, publishes one stream entry.
  - **idempotent replay flow**: second request returns `200 OK` with replay flag, and does **not** create duplicate DB rows or stream entries.
- Tuned test runtime stability for async outbox publishing (polling with timeout, shorter outbox interval in tests).
- While enabling real E2E execution, fixed infrastructure SQL mapping issues surfaced by Postgres:
  - Cast payload inserts to `jsonb` where needed.
  - Added explicit SQL aliases for snake_case-to-DTO mapping consistency.

### Why
The previous integration tests used in-memory fakes and did not validate real PostgreSQL constraints nor Redis stream publish behavior. This change aligns tests with production-like behavior and validates idempotency guarantees end-to-end.

## Related Issue
Closes #37 
Refs #4 

## Checklist
- [x] Linked to an issue (Closes #37 /Refs #4 )
- [x] Follows architecture boundaries
- [x] Tests updated/added if needed
- [x] CI is green