### PR TITLE
test(api): cover header precedence and invalid correlation-id fallback in ingestion integration tests

### DIFF
--- a/docs/02-event-contract.md
+++ b/docs/02-event-contract.md
@@ -74,3 +74,4 @@ For idempotent replay (`tenant_id` + `idempotency_key` already exists):
 
 - `Idempotency-Key` header has precedence over body `idempotency_key`.
 - `X-Correlation-Id` header has precedence over body `correlation_id`.
+- If `X-Correlation-Id` is present but invalid (not a UUID), it is ignored: use body `correlation_id` when valid, otherwise generate a new correlation id.

--- a/tests/IntegrationTests/Api/EventIngestionApiTests.cs
+++ b/tests/IntegrationTests/Api/EventIngestionApiTests.cs
@@ -109,4 +109,168 @@ public class EventIngestionApiTests : IClassFixture<CustomWebApplicationFactory>
         var streamLength = await _factory.GetStreamLengthAsync();
         Assert.Equal(1, streamLength);
     }
+
+    [Fact]
+    public async Task PostEvents_UsesHeaderIdempotencyKey_WhenHeaderAndBodyProvideDifferentValues()
+    {
+        await _factory.ResetStateAsync();
+
+        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = new Uri("https://localhost")
+        });
+
+        const string tenantId = "tenant-a";
+        const string headerIdempotencyKey = "idem-header-precedence-1";
+        const string bodyIdempotencyKey = "idem-body-precedence-1";
+        var request = new
+        {
+            event_type = "user.created",
+            source = "integration-tests",
+            tenant_id = tenantId,
+            idempotency_key = bodyIdempotencyKey,
+            payload = new { user_id = "u-2" }
+        };
+
+        var message = new HttpRequestMessage(HttpMethod.Post, "/events")
+        {
+            Content = JsonContent.Create(request)
+        };
+        message.Headers.Add("Idempotency-Key", headerIdempotencyKey);
+
+        var response = await client.SendAsync(message);
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+        await _factory.WaitForStreamLengthAsync(expectedLength: 1, timeout: TimeSpan.FromSeconds(10));
+
+        var headerRows = await _factory.CountEventsByTenantAndIdempotencyKeyAsync(tenantId, headerIdempotencyKey);
+        var bodyRows = await _factory.CountEventsByTenantAndIdempotencyKeyAsync(tenantId, bodyIdempotencyKey);
+
+        Assert.Equal(1, headerRows);
+        Assert.Equal(0, bodyRows);
+    }
+
+    [Fact]
+    public async Task PostEvents_UsesHeaderCorrelationId_WhenHeaderAndBodyProvideDifferentValues()
+    {
+        await _factory.ResetStateAsync();
+
+        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = new Uri("https://localhost")
+        });
+
+        const string tenantId = "tenant-a";
+        const string idempotencyKey = "idem-correlation-precedence-1";
+        var bodyCorrelationId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var headerCorrelationId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+        var request = new
+        {
+            event_type = "user.created",
+            source = "integration-tests",
+            tenant_id = tenantId,
+            correlation_id = bodyCorrelationId,
+            payload = new { user_id = "u-3" }
+        };
+
+        var message = new HttpRequestMessage(HttpMethod.Post, "/events")
+        {
+            Content = JsonContent.Create(request)
+        };
+        message.Headers.Add("Idempotency-Key", idempotencyKey);
+        message.Headers.Add("X-Correlation-Id", headerCorrelationId.ToString());
+
+        var response = await client.SendAsync(message);
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+        await _factory.WaitForStreamLengthAsync(expectedLength: 1, timeout: TimeSpan.FromSeconds(10));
+
+        var storedCorrelationId = await _factory.GetCorrelationIdByTenantAndIdempotencyKeyAsync(tenantId, idempotencyKey);
+        Assert.Equal(headerCorrelationId, storedCorrelationId);
+    }
+
+    [Fact]
+    public async Task PostEvents_UsesBodyCorrelationId_WhenCorrelationHeaderIsInvalid()
+    {
+        await _factory.ResetStateAsync();
+
+        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = new Uri("https://localhost")
+        });
+
+        const string tenantId = "tenant-a";
+        const string idempotencyKey = "idem-correlation-invalid-header-1";
+        var bodyCorrelationId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+
+        var request = new
+        {
+            event_type = "user.created",
+            source = "integration-tests",
+            tenant_id = tenantId,
+            correlation_id = bodyCorrelationId,
+            payload = new { user_id = "u-4" }
+        };
+
+        var message = new HttpRequestMessage(HttpMethod.Post, "/events")
+        {
+            Content = JsonContent.Create(request)
+        };
+        message.Headers.Add("Idempotency-Key", idempotencyKey);
+        message.Headers.Add("X-Correlation-Id", "not-a-guid");
+
+        var response = await client.SendAsync(message);
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+        await _factory.WaitForStreamLengthAsync(expectedLength: 1, timeout: TimeSpan.FromSeconds(10));
+
+        var storedCorrelationId = await _factory.GetCorrelationIdByTenantAndIdempotencyKeyAsync(tenantId, idempotencyKey);
+        Assert.Equal(bodyCorrelationId, storedCorrelationId);
+    }
+
+    [Fact]
+    public async Task PostEvents_GeneratesCorrelationId_WhenCorrelationHeaderIsInvalidAndBodyIsMissing()
+    {
+        await _factory.ResetStateAsync();
+
+        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = new Uri("https://localhost")
+        });
+
+        const string tenantId = "tenant-a";
+        const string idempotencyKey = "idem-correlation-invalid-header-2";
+
+        var request = new
+        {
+            event_type = "user.created",
+            source = "integration-tests",
+            tenant_id = tenantId,
+            payload = new { user_id = "u-5" }
+        };
+
+        var message = new HttpRequestMessage(HttpMethod.Post, "/events")
+        {
+            Content = JsonContent.Create(request)
+        };
+        message.Headers.Add("Idempotency-Key", idempotencyKey);
+        message.Headers.Add("X-Correlation-Id", "still-not-a-guid");
+
+        var response = await client.SendAsync(message);
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+        await _factory.WaitForStreamLengthAsync(expectedLength: 1, timeout: TimeSpan.FromSeconds(10));
+
+        var storedCorrelationId = await _factory.GetCorrelationIdByTenantAndIdempotencyKeyAsync(tenantId, idempotencyKey);
+        Assert.NotEqual(Guid.Empty, storedCorrelationId);
+    }
 }


### PR DESCRIPTION
## Summary
This PR adds integration test coverage for ingestion contract rules around request/header precedence and correlation-id parsing behavior.

### What changed
- Added tests to verify `Idempotency-Key` header precedence over body `idempotency_key`.
- Added tests to verify `X-Correlation-Id` header precedence over body `correlation_id` when the header is a valid UUID.
- Added tests to verify invalid `X-Correlation-Id` fallback behavior:
  - invalid header is ignored,
  - body `correlation_id` is used when present,
  - a new correlation id is generated when body value is missing.
- Added a test fixture helper to fetch persisted `correlation_id` for deterministic assertions.
- Updated documentation to make invalid `X-Correlation-Id` behavior explicit in the event contract.

### Why
Header precedence and invalid correlation-id handling are core API contract rules and were not explicitly validated by integration tests. This PR makes those rules executable and prevents regressions.

## Related Issue
Closes #39 
Refs #4 

## Checklist
- [x] Linked to an issue (Closes #39 / Refs #4 )
- [x] Follows architecture boundaries
- [x] Tests updated/added if needed
- [x] CI is green