### PR TITLE
feat(api): add health endpoint

### DIFF
--- a/src/EventIngestion.Api/Health/DatabaseReadinessHealthCheck.cs
+++ b/src/EventIngestion.Api/Health/DatabaseReadinessHealthCheck.cs
@@ -1,0 +1,47 @@
+using System.Data.Common;
+using EventPlatform.Infrastructure.Persistence.DataAccess;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace EventIngestion.Api.Health;
+
+internal sealed class DatabaseReadinessHealthCheck : IHealthCheck
+{
+    private readonly IDbConnectionFactory _connectionFactory;
+
+    public DatabaseReadinessHealthCheck(IDbConnectionFactory connectionFactory)
+    {
+        _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var connection = _connectionFactory.CreateConnection();
+
+            if (connection is DbConnection dbConnection)
+            {
+                await dbConnection.OpenAsync(cancellationToken);
+
+                await using var command = dbConnection.CreateCommand();
+                command.CommandText = "SELECT 1;";
+                _ = await command.ExecuteScalarAsync(cancellationToken);
+            }
+            else
+            {
+                connection.Open();
+                using var command = connection.CreateCommand();
+                command.CommandText = "SELECT 1;";
+                _ = command.ExecuteScalar();
+            }
+
+            return HealthCheckResult.Healthy("PostgreSQL is reachable.");
+        }
+        catch (Exception exception)
+        {
+            return HealthCheckResult.Unhealthy("PostgreSQL readiness check failed.", exception);
+        }
+    }
+}

--- a/src/EventIngestion.Api/Health/RedisReadinessHealthCheck.cs
+++ b/src/EventIngestion.Api/Health/RedisReadinessHealthCheck.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using StackExchange.Redis;
+
+namespace EventIngestion.Api.Health;
+
+internal sealed class RedisReadinessHealthCheck : IHealthCheck
+{
+    private readonly IConnectionMultiplexer _connectionMultiplexer;
+
+    public RedisReadinessHealthCheck(IConnectionMultiplexer connectionMultiplexer)
+    {
+        _connectionMultiplexer = connectionMultiplexer ?? throw new ArgumentNullException(nameof(connectionMultiplexer));
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (!_connectionMultiplexer.IsConnected)
+            {
+                return HealthCheckResult.Unhealthy("Redis is not connected.");
+            }
+
+            var database = _connectionMultiplexer.GetDatabase();
+            _ = await database.PingAsync();
+
+            return HealthCheckResult.Healthy("Redis is reachable.");
+        }
+        catch (Exception exception)
+        {
+            return HealthCheckResult.Unhealthy("Redis readiness check failed.", exception);
+        }
+    }
+}

--- a/src/EventIngestion.Api/Program.cs
+++ b/src/EventIngestion.Api/Program.cs
@@ -1,5 +1,6 @@
 using EventIngestion.Api.Correlation;
 using EventIngestion.Api.Contracts;
+using EventIngestion.Api.Health;
 using EventIngestion.Api.Ingestion;
 using EventPlatform.Application.Abstractions;
 using EventPlatform.Domain.Events;
@@ -8,12 +9,18 @@ using EventPlatform.Infrastructure.Messaging;
 using EventPlatform.Infrastructure.Persistence.Exceptions;
 using EventPlatform.Infrastructure.Persistence.Repositories;
 using FluentValidation;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using System.Text.Json;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddOpenApi();
+builder.Services
+    .AddHealthChecks()
+    .AddCheck<DatabaseReadinessHealthCheck>("postgres", HealthStatus.Unhealthy, ["ready"])
+    .AddCheck<RedisReadinessHealthCheck>("redis", HealthStatus.Unhealthy, ["ready"]);
 builder.Services.AddHttpsRedirection(options =>
 {
     options.HttpsPort = builder.Configuration.GetValue<int?>("HttpsRedirection:HttpsPort") ?? 7267;
@@ -66,6 +73,22 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 app.UseMiddleware<CorrelationIdMiddleware>();
+app.MapHealthChecks("/health", new HealthCheckOptions
+{
+    Predicate = registration => registration.Tags.Contains("ready"),
+    ResponseWriter = async (httpContext, report) =>
+    {
+        httpContext.Response.ContentType = "application/json";
+
+        await JsonSerializer.SerializeAsync(httpContext.Response.Body, new
+        {
+            status = report.Status.ToString(),
+            checks = report.Entries.ToDictionary(
+                entry => entry.Key,
+                entry => entry.Value.Status.ToString())
+        });
+    }
+});
 
 app.MapPost("/events", async (
     IngestEventRequest request,

--- a/tests/IntegrationTests/Api/HealthEndpointTests.cs
+++ b/tests/IntegrationTests/Api/HealthEndpointTests.cs
@@ -1,0 +1,39 @@
+using System.Net;
+using System.Net.Http.Json;
+using EventPlatform.IntegrationTests.Fixtures;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace EventPlatform.IntegrationTests.Api;
+
+[Collection(nameof(ApiTestsCollection))]
+public sealed class HealthEndpointTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly CustomWebApplicationFactory _factory;
+
+    public HealthEndpointTests(CustomWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GetHealth_ReturnsHealthy_WhenDbAndRedisAreReachable()
+    {
+        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = new Uri("https://localhost")
+        });
+
+        var response = await client.GetAsync("/health");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var payload = await response.Content.ReadFromJsonAsync<HealthResponse>();
+        Assert.NotNull(payload);
+        Assert.Equal("Healthy", payload.Status);
+        Assert.Equal("Healthy", payload.Checks["postgres"]);
+        Assert.Equal("Healthy", payload.Checks["redis"]);
+    }
+
+    private sealed record HealthResponse(string Status, Dictionary<string, string> Checks);
+}


### PR DESCRIPTION
## Summary

- **What**: Added API readiness endpoint `GET /health` with explicit checks for PostgreSQL and Redis.
- **Why**: Expose system readiness for orchestration/monitoring and satisfy issue #12 observability requirements.

## Type of Change

- [x] `feat`: A new feature
- [ ] `fix`: A bug fix
- [ ] `docs`: Documentation only changes
- [ ] `refactor`: A code change that neither fixes a bug nor adds a feature
- [ ] `test`: Adding missing tests or correcting existing tests
- [ ] `chore`: Changes to the build process or auxiliary tools

## Related Issue

Closes #12

## Architectural Integrity

- [x] Domain Invariants: `EventEnvelope`/`EventLifecycle` state model was not modified; existing transitions remain intact.
- [x] Boundary Rules: New health checks live in API and consume Infrastructure abstractions (`IDbConnectionFactory`, `IConnectionMultiplexer`) without introducing Infrastructure dependencies into Domain/Application.
- [x] Outbox Pattern: Existing ingestion flow still uses `InsertWithOutboxAsync`; this PR does not change outbox write semantics.
- [x] Idempotency: Worker redelivery/idempotency behavior is unchanged by this PR.

## Testing & Coverage

- [ ] Unit Tests: No new unit tests added in this PR.
- [x] Integration Tests: Added `HealthEndpointTests` using existing `CustomWebApplicationFactory` (Testcontainers PostgreSQL/Redis).
- [ ] Coverage Gate: Could not verify in this environment because `dotnet build/test` exits with `NETSDK1057` (preview SDK policy message) and exit code 1.

## Database & Migrations

- [x] New migrations follow the **Expand and Contract** pattern (no destructive changes).
- [ ] `DbMigrator` has been executed and verified locally. (No schema changes in this PR)

## Checklist

- [x] PR title follows **Conventional Commits** format.
- [x] Linked to an issue (Closes #12).
- [x] No hardcoded secrets or connection strings.
- [ ] Documentation/ADRs updated if architecture was modified. (Not required: no architecture boundary change)
