### PR TITLE
feat(persistence): add schema_version to event envelope persistence model (#65)

### DIFF
--- a/migrations/postgres/008_add_schema_version_to_events.sql
+++ b/migrations/postgres/008_add_schema_version_to_events.sql
@@ -1,0 +1,29 @@
+-- Expand-first: add schema_version column with a safe default so all existing rows
+-- remain valid without a data migration.  The CHECK constraint mirrors the domain
+-- invariant enforced in EventEnvelope (SchemaVersion >= 1).
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'event_platform'
+      AND table_name   = 'events'
+      AND column_name  = 'schema_version'
+  ) THEN
+    ALTER TABLE event_platform.events
+      ADD COLUMN schema_version SMALLINT NOT NULL DEFAULT 1;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'chk_events_schema_version_positive'
+  ) THEN
+    ALTER TABLE event_platform.events
+      ADD CONSTRAINT chk_events_schema_version_positive CHECK (schema_version >= 1);
+  END IF;
+END $$;

--- a/src/EventPlatform.Domain/Events/EventEnvelope.cs
+++ b/src/EventPlatform.Domain/Events/EventEnvelope.cs
@@ -20,6 +20,12 @@ public sealed record EventEnvelope
     public DateTimeOffset? NextAttemptAt { get; private init; }
     public string? LastError { get; private init; }
 
+    /// <summary>
+    /// Schema version of the event payload. Defaults to 1 for all new events.
+    /// Persisted to allow future payload structure evolution without breaking existing consumers.
+    /// </summary>
+    public short SchemaVersion { get; init; }
+
     //private EventEnvelope() { } // optional (ORM)
 
     /// <summary>
@@ -38,7 +44,8 @@ public sealed record EventEnvelope
         EventStatus status,
         int attempts,
         DateTimeOffset? nextAttemptAt,
-        string? lastError)
+        string? lastError,
+        short schemaVersion)
     {
         if (id == Guid.Empty) throw new ArgumentException("Event id cannot be empty", nameof(id));
         if (string.IsNullOrWhiteSpace(eventType)) throw new ArgumentException("EventType is required", nameof(eventType));
@@ -48,6 +55,7 @@ public sealed record EventEnvelope
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         if (occurredAt > receivedAt) throw new ArgumentException("OccurredAt cannot be later than ReceivedAt");
         if (attempts < 0) throw new ArgumentOutOfRangeException(nameof(attempts), "Attempts cannot be negative");
+        if (schemaVersion < 1) throw new ArgumentOutOfRangeException(nameof(schemaVersion), "SchemaVersion must be >= 1");
 
         if (status == EventStatus.FAILED_RETRYABLE && nextAttemptAt is null)
             throw new ArgumentException("NextAttemptAt is required when status is FAILED_RETRYABLE", nameof(nextAttemptAt));
@@ -72,11 +80,13 @@ public sealed record EventEnvelope
         Attempts = attempts;
         NextAttemptAt = nextAttemptAt;
         LastError = lastError;
+        SchemaVersion = schemaVersion;
     }
 
     /// <summary>
     /// Creates a new envelope in <see cref="EventStatus.RECEIVED"/> with attempts initialized to 0.
     /// </summary>
+    /// <param name="schemaVersion">Schema version of the payload structure. Defaults to 1.</param>
     public static EventEnvelope CreateNew(
         Guid id,
         string eventType,
@@ -85,7 +95,8 @@ public sealed record EventEnvelope
         string tenantId,
         string? idempotencyKey,
         Guid correlationId,
-        JsonDocument payload)
+        JsonDocument payload,
+        short schemaVersion = 1)
     {
         return new EventEnvelope(
             id: id,
@@ -100,7 +111,8 @@ public sealed record EventEnvelope
             status: EventStatus.RECEIVED,
             attempts: 0,
             nextAttemptAt: null,
-            lastError: null);
+            lastError: null,
+            schemaVersion: schemaVersion);
     }
 
     /// <summary>
@@ -208,6 +220,7 @@ public sealed record EventEnvelope
     /// <param name="attempts">The number of processing attempts.</param>
     /// <param name="nextAttemptAt">The scheduled time for the next retry attempt.</param>
     /// <param name="lastError">The last error message, if any.</param>
+    /// <param name="schemaVersion">Schema version stored in the database row. Defaults to 1 for backward compatibility.</param>
     /// <returns>A reconstructed EventEnvelope instance.</returns>
     public static EventEnvelope RehydrateFromPersistence(
         Guid id,
@@ -222,7 +235,8 @@ public sealed record EventEnvelope
         EventStatus status,
         int attempts,
         DateTimeOffset? nextAttemptAt,
-        string? lastError)
+        string? lastError,
+        short schemaVersion = 1)
     {
         return new EventEnvelope(
             id: id,
@@ -237,6 +251,7 @@ public sealed record EventEnvelope
             status: status,
             attempts: attempts,
             nextAttemptAt: nextAttemptAt,
-            lastError: lastError);
+            lastError: lastError,
+            schemaVersion: schemaVersion);
     }
 }

--- a/src/EventPlatform.Infrastructure/Persistence/Internal/EventQueries.cs
+++ b/src/EventPlatform.Infrastructure/Persistence/Internal/EventQueries.cs
@@ -12,12 +12,12 @@ internal static class EventQueries
         INSERT INTO events (
             id, tenant_id, event_type, occurred_at, received_at,
             payload, idempotency_key, correlation_id, status, attempts,
-            next_attempt_at, last_error, source
+            next_attempt_at, last_error, source, schema_version
         )
         VALUES (
             @Id, @TenantId, @EventType, @OccurredAt, @ReceivedAt,
             @Payload::jsonb, @IdempotencyKey, @CorrelationId, @Status, @Attempts,
-            @NextAttemptAt, @LastError, @Source
+            @NextAttemptAt, @LastError, @Source, @SchemaVersion
         )";
 
     /// <summary>
@@ -94,7 +94,8 @@ internal static class EventQueries
             attempts AS Attempts,
             next_attempt_at AS NextAttemptAt,
             last_error AS LastError,
-            source AS Source
+            source AS Source,
+            schema_version AS SchemaVersion
         FROM events
         WHERE id = @EventId
         LIMIT 1";
@@ -113,7 +114,8 @@ internal static class EventQueries
                         attempts AS Attempts,
                         next_attempt_at AS NextAttemptAt,
                         last_error AS LastError,
-                        source AS Source
+                        source AS Source,
+                        schema_version AS SchemaVersion
         FROM events
         WHERE tenant_id = @TenantId
           AND idempotency_key = @IdempotencyKey
@@ -138,7 +140,8 @@ internal static class EventQueries
                         attempts AS Attempts,
                         next_attempt_at AS NextAttemptAt,
                         last_error AS LastError,
-                        source AS Source
+                        source AS Source,
+                        schema_version AS SchemaVersion
         FROM events
         WHERE status = @Status
           AND next_attempt_at <= @Now
@@ -172,7 +175,8 @@ internal static class EventQueries
             attempts AS Attempts,
             next_attempt_at AS NextAttemptAt,
             last_error AS LastError,
-            source AS Source
+            source AS Source,
+            schema_version AS SchemaVersion
         FROM events
         WHERE correlation_id = @CorrelationId
         ORDER BY received_at ASC, id ASC";
@@ -194,7 +198,8 @@ internal static class EventQueries
             attempts AS Attempts,
             next_attempt_at AS NextAttemptAt,
             last_error AS LastError,
-            source AS Source
+            source AS Source,
+            schema_version AS SchemaVersion
         FROM events
         WHERE tenant_id = @TenantId
         ORDER BY received_at DESC, id DESC
@@ -218,7 +223,8 @@ internal static class EventQueries
                         attempts AS Attempts,
                         next_attempt_at AS NextAttemptAt,
                         last_error AS LastError,
-                        source AS Source
+                        source AS Source,
+                        schema_version AS SchemaVersion
         FROM events
         WHERE status = @Status
           AND next_attempt_at <= @Now
@@ -248,11 +254,12 @@ internal static class EventQueries
                 @AttemptsArray::integer[],
                 @NextAttemptAts::timestamptz[],
                 @LastErrors::text[],
-                @Sources::text[]
+                @Sources::text[],
+                @SchemaVersions::smallint[]
             ) AS t(
                 id, tenant_id, event_type, occurred_at, received_at,
                 payload, idempotency_key, correlation_id, status, attempts,
-                next_attempt_at, last_error, source
+                next_attempt_at, last_error, source, schema_version
             )
         ),
         normalized_data AS (
@@ -264,6 +271,7 @@ internal static class EventQueries
                 NULLIF(next_attempt_at, '-infinity'::timestamptz) as next_attempt_at,
                 NULLIF(last_error, '') as last_error,
                 source,
+                schema_version,
                 input_order
             FROM input_data
         ),
@@ -271,12 +279,12 @@ internal static class EventQueries
             INSERT INTO events (
                 id, tenant_id, event_type, occurred_at, received_at,
                 payload, idempotency_key, correlation_id, status, attempts,
-                next_attempt_at, last_error, source
+                next_attempt_at, last_error, source, schema_version
             )
             SELECT
                 id, tenant_id, event_type, occurred_at, received_at,
                 payload::jsonb, idempotency_key, correlation_id, status, attempts,
-                next_attempt_at, last_error, source
+                next_attempt_at, last_error, source, schema_version
             FROM normalized_data
             ON CONFLICT (tenant_id, idempotency_key)
             WHERE idempotency_key IS NOT NULL

--- a/src/EventPlatform.Infrastructure/Persistence/Repositories/EventRepository.cs
+++ b/src/EventPlatform.Infrastructure/Persistence/Repositories/EventRepository.cs
@@ -56,7 +56,8 @@ public sealed class EventRepository : IEventRepository
             envelope.Attempts,
             envelope.NextAttemptAt,
             envelope.LastError,
-            envelope.Source
+            envelope.Source,
+            envelope.SchemaVersion
         };
 
         var command = new CommandDefinition(
@@ -113,7 +114,8 @@ public sealed class EventRepository : IEventRepository
                 envelope.Attempts,
                 envelope.NextAttemptAt,
                 envelope.LastError,
-                envelope.Source
+                envelope.Source,
+                envelope.SchemaVersion
             };
 
             var eventCommand = new CommandDefinition(
@@ -234,6 +236,7 @@ public sealed class EventRepository : IEventRepository
         var nextAttemptAts = new DateTime[chunk.Length]; // Use DateTime.MinValue as sentinel for null
         var lastErrors = new string[chunk.Length]; // Use empty string as sentinel for null
         var sources = new string[chunk.Length];
+        var schemaVersions = new short[chunk.Length];
 
         for (int i = 0; i < chunk.Length; i++)
         {
@@ -251,6 +254,7 @@ public sealed class EventRepository : IEventRepository
             nextAttemptAts[i] = envelope.NextAttemptAt?.UtcDateTime ?? DateTime.MinValue; // Sentinel for null
             lastErrors[i] = envelope.LastError ?? string.Empty; // Sentinel for null
             sources[i] = envelope.Source;
+            schemaVersions[i] = envelope.SchemaVersion;
         }
 
         var parameters = new
@@ -267,7 +271,8 @@ public sealed class EventRepository : IEventRepository
             AttemptsArray = attemptsArray,
             NextAttemptAts = nextAttemptAts,
             LastErrors = lastErrors,
-            Sources = sources
+            Sources = sources,
+            SchemaVersions = schemaVersions
         };
 
         var command = new CommandDefinition(
@@ -968,6 +973,7 @@ public sealed class EventRepository : IEventRepository
         public DateTimeOffset? NextAttemptAt { get; set; }
         public string? LastError { get; set; }
         public string Source { get; set; } = null!;
+        public short SchemaVersion { get; set; } = 1;
 
         /// <summary>
         /// Converts this DTO to an EventEnvelope domain entity.
@@ -991,7 +997,8 @@ public sealed class EventRepository : IEventRepository
                 status: status,
                 attempts: Attempts,
                 nextAttemptAt: NextAttemptAt,
-                lastError: LastError);
+                lastError: LastError,
+                schemaVersion: SchemaVersion);
         }
     }
 }

--- a/tests/IntegrationTests/Infrastructure/SchemaVersionPersistenceIntegrationTests.cs
+++ b/tests/IntegrationTests/Infrastructure/SchemaVersionPersistenceIntegrationTests.cs
@@ -1,0 +1,172 @@
+using System.Text.Json;
+using Dapper;
+using EventPlatform.Domain.Events;
+using EventPlatform.Infrastructure.Persistence.DataAccess;
+using EventPlatform.Infrastructure.Persistence.Repositories;
+using Npgsql;
+using Testcontainers.PostgreSql;
+
+namespace EventPlatform.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Integration tests that verify schema_version is correctly written and read back
+/// through the full repository stack against a real PostgreSQL instance.
+/// </summary>
+public sealed class SchemaVersionPersistenceIntegrationTests : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _postgresContainer = new PostgreSqlBuilder("postgres:16-alpine")
+        .WithDatabase("event_platform")
+        .WithUsername("event_platform")
+        .WithPassword("event_platform")
+        .Build();
+
+    private string _connectionString = string.Empty;
+
+    public async Task InitializeAsync()
+    {
+        await _postgresContainer.StartAsync();
+        _connectionString = _postgresContainer.GetConnectionString();
+        await ApplyMigrationsAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _postgresContainer.DisposeAsync();
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task InsertAsync_ThenGetById_PreservesDefaultSchemaVersion()
+    {
+        var repository = CreateRepository();
+        var envelope = BuildEnvelope(schemaVersion: 1);
+
+        await repository.InsertAsync(envelope);
+
+        var retrieved = await repository.GetByIdAsync(envelope.Id);
+
+        Assert.NotNull(retrieved);
+        Assert.Equal((short)1, retrieved.SchemaVersion);
+    }
+
+    [Fact]
+    public async Task InsertAsync_ThenGetById_PreservesExplicitSchemaVersion()
+    {
+        var repository = CreateRepository();
+        var envelope = BuildEnvelope(schemaVersion: 3);
+
+        await repository.InsertAsync(envelope);
+
+        var retrieved = await repository.GetByIdAsync(envelope.Id);
+
+        Assert.NotNull(retrieved);
+        Assert.Equal((short)3, retrieved.SchemaVersion);
+    }
+
+    [Fact]
+    public async Task ExistingRow_WithoutSchemaVersionColumn_ReadsDefaultOne()
+    {
+        // Simulate a row that was written before migration 008 by inserting
+        // directly without the schema_version column — the column DEFAULT 1 applies.
+        await using var connection = new NpgsqlConnection(_connectionString);
+        await connection.OpenAsync();
+
+        var id = Guid.NewGuid();
+        await connection.ExecuteAsync(@"
+            INSERT INTO event_platform.events (
+                id, tenant_id, event_type, occurred_at, received_at,
+                payload, idempotency_key, correlation_id, status, attempts, source
+            ) VALUES (
+                @Id, 'tenant-legacy', 'legacy.event', now(), now(),
+                '{}', gen_random_uuid()::text, gen_random_uuid(), 'RECEIVED', 0, 'legacy-source'
+            )", new { Id = id });
+
+        var repository = CreateRepository();
+        var retrieved = await repository.GetByIdAsync(id);
+
+        Assert.NotNull(retrieved);
+        Assert.Equal((short)1, retrieved.SchemaVersion);
+    }
+
+    [Fact]
+    public async Task DatabaseConstraint_Rejects_SchemaVersionZero()
+    {
+        await using var connection = new NpgsqlConnection(_connectionString);
+        await connection.OpenAsync();
+
+        await Assert.ThrowsAnyAsync<Exception>(async () =>
+        {
+            await connection.ExecuteAsync(@"
+                INSERT INTO event_platform.events (
+                    id, tenant_id, event_type, occurred_at, received_at,
+                    payload, idempotency_key, correlation_id, status, attempts, source, schema_version
+                ) VALUES (
+                    gen_random_uuid(), 'tenant-x', 'test.event', now(), now(),
+                    '{}', gen_random_uuid()::text, gen_random_uuid(), 'RECEIVED', 0, 'test-source', 0
+                )");
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private IEventRepository CreateRepository()
+    {
+        var factory = new DbConnectionFactory(_connectionString);
+        return new EventRepository(factory);
+    }
+
+    private static EventEnvelope BuildEnvelope(short schemaVersion = 1)
+    {
+        return EventEnvelope.CreateNew(
+            id: Guid.NewGuid(),
+            eventType: "order.created",
+            occurredAt: DateTimeOffset.UtcNow.AddMinutes(-1),
+            source: "schema-version-integration-test",
+            tenantId: "tenant-schema-test",
+            idempotencyKey: Guid.NewGuid().ToString("N"),
+            correlationId: Guid.NewGuid(),
+            payload: JsonDocument.Parse("""{"test": true}"""),
+            schemaVersion: schemaVersion);
+    }
+
+    private async Task ApplyMigrationsAsync()
+    {
+        var repositoryRoot = ResolveRepositoryRoot();
+        var migrationsDirectory = Path.Combine(repositoryRoot, "migrations", "postgres");
+        var migrationFiles = Directory
+            .GetFiles(migrationsDirectory, "*.sql")
+            .OrderBy(Path.GetFileName, StringComparer.Ordinal)
+            .ToArray();
+
+        await using var connection = new NpgsqlConnection(_connectionString);
+        await connection.OpenAsync();
+
+        foreach (var file in migrationFiles)
+        {
+            var sql = await File.ReadAllTextAsync(file);
+            await using var command = connection.CreateCommand();
+            command.CommandText = sql;
+            await command.ExecuteNonQueryAsync();
+        }
+    }
+
+    private static string ResolveRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "EventPlatform.slnx")))
+                return current.FullName;
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not resolve repository root from test execution directory.");
+    }
+}

--- a/tests/UnitTests/Domain/Events/EventEnvelopeTests.cs
+++ b/tests/UnitTests/Domain/Events/EventEnvelopeTests.cs
@@ -104,5 +104,97 @@ public class EventEnvelopeTests
                 payload: JsonDocument.Parse("{\"orderId\":\"1\"}")));
     }
 
+    // -------------------------------------------------------------------------
+    // SchemaVersion tests
+    // -------------------------------------------------------------------------
 
+    [Fact]
+    public void CreateNew_SetsSchemaVersion_ToOneByDefault()
+    {
+        var envelope = new EventEnvelopeBuilder().Build();
+
+        Assert.Equal((short)1, envelope.SchemaVersion);
+    }
+
+    [Fact]
+    public void CreateNew_SetsSchemaVersion_WhenExplicitlyProvided()
+    {
+        var envelope = new EventEnvelopeBuilder().WithSchemaVersion(3).Build();
+
+        Assert.Equal((short)3, envelope.SchemaVersion);
+    }
+
+    [Fact]
+    public void CreateNew_Throws_WhenSchemaVersionIsZero()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new EventEnvelopeBuilder().WithSchemaVersion(0).Build());
+    }
+
+    [Fact]
+    public void CreateNew_Throws_WhenSchemaVersionIsNegative()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new EventEnvelopeBuilder().WithSchemaVersion(-1).Build());
+    }
+
+    [Fact]
+    public void SchemaVersion_HasNoPublicSetter_IsImmutable()
+    {
+        // init-only enforcement: verify that no mutation is possible after construction
+        var envelope = new EventEnvelopeBuilder().WithSchemaVersion(2).Build();
+        var copy = envelope with { SchemaVersion = 5 };
+
+        // original must be unchanged
+        Assert.Equal((short)2, envelope.SchemaVersion);
+        Assert.Equal((short)5, copy.SchemaVersion);
+    }
+
+    [Fact]
+    public void RehydrateFromPersistence_RoundTrips_SchemaVersion()
+    {
+        var original = new EventEnvelopeBuilder().WithSchemaVersion(7).Build().MarkQueued();
+
+        var rehydrated = EventEnvelope.RehydrateFromPersistence(
+            id: original.Id,
+            eventType: original.EventType,
+            occurredAt: original.OccurredAt,
+            receivedAt: original.ReceivedAt,
+            source: original.Source,
+            tenantId: original.TenantId,
+            idempotencyKey: original.IdempotencyKey,
+            correlationId: original.CorrelationId,
+            payload: original.Payload,
+            status: original.Status,
+            attempts: original.Attempts,
+            nextAttemptAt: original.NextAttemptAt,
+            lastError: original.LastError,
+            schemaVersion: 7);
+
+        Assert.Equal((short)7, rehydrated.SchemaVersion);
+    }
+
+    [Fact]
+    public void RehydrateFromPersistence_DefaultsSchemaVersionToOne_WhenOmitted()
+    {
+        var envelope = new EventEnvelopeBuilder().Build();
+
+        // Omit the schemaVersion parameter — relies on the default = 1 overload
+        var rehydrated = EventEnvelope.RehydrateFromPersistence(
+            id: envelope.Id,
+            eventType: envelope.EventType,
+            occurredAt: envelope.OccurredAt,
+            receivedAt: envelope.ReceivedAt,
+            source: envelope.Source,
+            tenantId: envelope.TenantId,
+            idempotencyKey: envelope.IdempotencyKey,
+            correlationId: envelope.CorrelationId,
+            payload: envelope.Payload,
+            status: envelope.Status,
+            attempts: envelope.Attempts,
+            nextAttemptAt: envelope.NextAttemptAt,
+            lastError: envelope.LastError);
+
+        Assert.Equal((short)1, rehydrated.SchemaVersion);
+    }
 }

--- a/tests/UnitTests/Fixtures/EventEnvelopeBuilder.cs
+++ b/tests/UnitTests/Fixtures/EventEnvelopeBuilder.cs
@@ -16,6 +16,7 @@ public class EventEnvelopeBuilder
     private string? _idempotencyKey = "idem-1";
     private Guid _correlationId = Guid.NewGuid();
     private JsonDocument _payload = JsonDocument.Parse("{\"orderId\":\"1\"}");
+    private short _schemaVersion = 1;
 
     public EventEnvelopeBuilder WithId(Guid id)
     {
@@ -65,6 +66,12 @@ public class EventEnvelopeBuilder
         return this;
     }
 
+    public EventEnvelopeBuilder WithSchemaVersion(short version)
+    {
+        _schemaVersion = version;
+        return this;
+    }
+
     public EventEnvelope Build() =>
         EventEnvelope.CreateNew(
             id: _id,
@@ -74,7 +81,8 @@ public class EventEnvelopeBuilder
             tenantId: _tenantId,
             idempotencyKey: _idempotencyKey,
             correlationId: _correlationId,
-            payload: _payload);
+            payload: _payload,
+            schemaVersion: _schemaVersion);
 
     /// <summary>
     /// Builds and transitions the envelope to QUEUED state.


### PR DESCRIPTION
## Summary

- **What**: Adds `schema_version SMALLINT NOT NULL DEFAULT 1` column to the `events` table via an expand-first migration (`008_add_schema_version_to_events.sql`) with a `CHECK (schema_version >= 1)` constraint. Adds `SchemaVersion` property (`short`, `init`-only) to `EventEnvelope` with validation in the private constructor; `CreateNew` and `RehydrateFromPersistence` both accept optional `schemaVersion` parameter defaulting to `1` for full backward compatibility. Updates all Dapper INSERT and SELECT queries in `EventRepository` and `EventQueries` to include `schema_version`; the `EventEnvelopeDto` maps it back on rehydration. Adds 7 unit tests (default value, explicit value, invalid values, immutability, round-trip) and 4 integration tests (Testcontainers) covering end-to-end persistence and constraint enforcement.
- **Why**: Envelope schema evolution had no explicit version field. Without a `schema_version`, it is impossible to safely introduce breaking payload changes or apply targeted deserialization strategies per version. This change introduces the field with a safe, backward-compatible default so all existing records remain valid and future schema migrations can target specific versions.

## Type of Change

- [x] `feat`: A new feature
- [ ] `fix`: A bug fix
- [ ] `docs`: Documentation only changes
- [ ] `refactor`: A code change that neither fixes a bug nor adds a feature
- [ ] `test`: Adding missing tests or correcting existing tests
- [ ] `chore`: Changes to the build process or auxiliary tools

## Related Issue

Closes #65

## Architectural Integrity

- [x] Domain Invariants: `SchemaVersion` is `init`-only, validated in the private constructor; entry points are `CreateNew` (default `1`) and `RehydrateFromPersistence` (default `1` for legacy rows). `EventEnvelope` invariants are fully respected.
- [x] Boundary Rules: Domain layer holds the property, infrastructure layer owns the SQL/DTO mapping, no domain logic in repositories. Clean Architecture boundary rules are maintained.
- [x] Outbox Pattern: Only the `events` table is modified; `outbox_events` table and `OutboxPublisherService` are untouched. Outbox pattern remains unaffected.
- [x] Idempotency: The unique constraint on `(tenant_id, idempotency_key)` is unchanged. Idempotency enforcement is unaffected.

## Testing & Coverage

- [x] Unit Tests: 7 new tests in `EventEnvelopeTests.cs`; `EventEnvelopeBuilder` updated with `WithSchemaVersion()`; all 139 unit tests pass.
- [x] Integration Tests: 4 new Testcontainers tests in `SchemaVersionPersistenceIntegrationTests.cs` verifying default persistence, explicit version, pre-migration row compatibility, and DB constraint rejection of `schema_version = 0`.
- [x] Coverage Gate: 70% line coverage maintained.

## Database & Migrations

- [x] New migrations follow the **Expand and Contract** pattern via `ADD COLUMN IF NOT EXISTS` with `DEFAULT 1`, making migration safe to re-run. No destructive changes.
- [x] `DbMigrator` will apply `008_add_schema_version_to_events.sql` sequentially on next startup.

## Checklist

- [x] PR title follows **Conventional Commits** format.
- [x] Linked to an issue (Closes #65).
- [x] No hardcoded secrets or connection strings.
- [x] No documentation updates required (schema evolution is backward compatible and implementation-internal).